### PR TITLE
fix(admin-dashboard): ticket description updates immediately after edit

### DIFF
--- a/src/routes/main/tickets/board/TicketsDetails.svelte
+++ b/src/routes/main/tickets/board/TicketsDetails.svelte
@@ -111,8 +111,9 @@
 		}
 	}
 
-	function handleSaveEditDescription() {
-		ticketsActions.updateTicketDescription(ticket.id, descriptionValue);
+	async function handleSaveEditDescription() {
+		await ticketsActions.updateTicketDescription(ticket.id, descriptionValue);
+		ticket = { ...ticket, description: descriptionValue };
 		isEditDescription = false;
 		descriptionValue = '';
 	}


### PR DESCRIPTION
<img width="1862" height="825" alt="image" src="https://github.com/user-attachments/assets/17e3dda1-4177-4ef9-af36-9934538cef1a" />
<img width="1889" height="778" alt="image" src="https://github.com/user-attachments/assets/c7eaf631-650a-4e8a-83a4-485f568a408d" />

Fixed the ticket description editing behavior in the Admin Dashboard so that after saving, the updated description is displayed immediately without requiring a page refresh or navigating away and back