### PR TITLE
fix(adminDashboard/users): fix page indicator not updating on pagination change

### DIFF
--- a/src/routes/main/users/UsersDataTable.svelte
+++ b/src/routes/main/users/UsersDataTable.svelte
@@ -104,7 +104,7 @@
 			</div>
 			<Pagination
 				count={totalCount}
-				page={pagination.page}
+				bind:page={pagination.page}
 				perPage={pagination.size}
 				onPageChange={handlePageChange}
 				class="w-fit"


### PR DESCRIPTION
<img width="1910" height="930" alt="image" src="https://github.com/user-attachments/assets/6b87f841-3430-41cf-8800-c22921e15be8" />

Resolves an issue in the Users list where the page indicator did not update when navigating between pagination pages.