### PR TITLE
fix(admin-sessions): remove horizontal scroll in sessions table

### DIFF
--- a/src/routes/main/profile/sessions/+page.svelte
+++ b/src/routes/main/profile/sessions/+page.svelte
@@ -47,8 +47,8 @@
 	{:else}
 		<div class="flex flex-col gap-2">
 			{#each meSessions as session}
-				<div class="rounded-md border border-border p-4">
-					<div class="flex items-center justify-between gap-6">
+				<div class="rounded-md border border-border p-2 max-w-[95%] overflow-hidden mx-auto">
+					<div class="flex items-center justify-between gap-3">
 						<TooltipProvider delayDuration={0}>
 							<Tooltip>
 								<TooltipTrigger class="max-w-[50%]">
@@ -59,7 +59,7 @@
 								</TooltipContent>
 							</Tooltip>
 						</TooltipProvider>
-						<div class="flex gap-2">
+						<div class="ml-auto flex flex-wrap items-center gap-2">
 							{#if session.is_revoked}
 								{@render expiredBadge()}
 							{:else}


### PR DESCRIPTION
<img width="1915" height="937" alt="image" src="https://github.com/user-attachments/assets/3ae1861a-0d4c-4dbb-821b-687a8ab60e01" />

The Sessions section in the SuperAdmin Profile Settings previously caused horizontal scrolling due to overflowing session rows and badges. 