### PR TITLE
fix(admin): prevent ticket creation limit from being set below 0

### DIFF
--- a/src/routes/main/system/settings/+page.svelte
+++ b/src/routes/main/system/settings/+page.svelte
@@ -107,6 +107,7 @@
 					</div>
 					<Input
 						type="number"
+						min="0"
 						bind:value={ticketCreationLimit}
 						onblur={() =>
 							handleUpdateSystemSettings({ number_of_tickets_creation_limit: ticketCreationLimit })}


### PR DESCRIPTION
https://drive.google.com/file/d/1zYRKWRLqC4P-SChpxM5RRzhtqFBqG8Qp/view?usp=sharing


Adds validation to prevent ticket creation limits from being set below 0.
